### PR TITLE
Update rexml gem version to fix CVE-2024-43398

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,7 +347,7 @@ GEM
     rake (13.0.6)
     rb-readline (0.5.5)
     regexp_parser (2.7.0)
-    rexml (3.2.5)
+    rexml (3.3.6)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)


### PR DESCRIPTION
## Context
Update the rexml gem version to fix  CVE-2024-43398-fix

## URL
https://www.ruby-lang.org/en/news/2024/08/22/dos-rexml-cve-2024-43398/

## Solution
Update Gemfile.lock file to upgrade the gem version